### PR TITLE
Workflow update

### DIFF
--- a/src/Chirp.CLI.Client/Chirp.CLI.csproj
+++ b/src/Chirp.CLI.Client/Chirp.CLI.csproj
@@ -20,6 +20,11 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>
     </Content>
+
+    <Content Include="Data\**">
+    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+  </Content>
   </ItemGroup>
   
 </Project>

--- a/src/Chirp.CLI.Client/Chirp.CLI.csproj
+++ b/src/Chirp.CLI.Client/Chirp.CLI.csproj
@@ -14,4 +14,12 @@
   <ItemGroup>
     <PackageReference Include="docopt.net" Version="0.8.1" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\Data\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
This update saves the chirp_cli_db.csv file in the zip files for the releases - The exe file still doesnt work, and that is because the csv file has a different path than in the actual project, so the exe file cant find it. We could develop a workaround, however this would be messy and we are going to use a different db system in the near future (azure), so doing this wouldnt be efficient. 